### PR TITLE
Update documentation, package entry-points after testing on Windows

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Install dependencies
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
-          sed -i '/msp/c\.\/msp' requirements.txt
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
           if [ -f requirements-dev.txt ]; then uv pip install --system -r requirements-dev.txt; fi
@@ -64,10 +63,10 @@ jobs:
       - name: Install dependencies
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
-          sed -i '/msp/c\.\/msp' requirements.txt
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
           if [ -f requirements-dev.txt ]; then uv pip install --system -r requirements-dev.txt; fi
+          uv pip install --system -e .
       - name: pytest
         run: |
           make test

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -38,9 +38,7 @@ and "help wanted" is open to whoever wants to implement it.
 Write Documentation
 ~~~~~~~~~~~~~~~~~~~
 
-Healthy-API could always use more documentation, whether as part of the
-official Healthy-API docs, in docstrings, or even on the web in blog posts,
-articles, and such.
+mzx could always use more documentation, whether in the Sphinx docs under ``docs/``, in docstrings, or in ``README.rst``.
 
 Submit Feedback
 ~~~~~~~~~~~~~~~
@@ -57,18 +55,26 @@ If you are proposing a feature:
 Get Started!
 ------------
 
-Ready to contribute? Here's how to set up `mzx` for local development.
+Ready to contribute? Here's how to set up **mzx** for local development.
 
-1. Fork the `mzx` repo on GitHub.
+1. Fork the `mzx`_ repo on GitHub.
 2. Clone your fork locally::
 
-    $ git clone git@github.com:your_name_here/mzx.git
+    $ git clone https://github.com/your_name_here/mzx.git
 
-3. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed, this is how you set up your fork for local development::
+3. Create a virtual environment and install dependencies. With `uv`_ (used by the Makefile)::
 
-    $ mkvirtualenv mzx
     $ cd mzx/
-    $ python setup.py develop
+    $ make setup
+    $ source .venv/bin/activate
+    $ make install
+
+   Or with plain pip::
+
+    $ python -m venv .venv
+    $ source .venv/bin/activate
+    $ pip install -r requirements.txt
+    $ pip install -e .
 
 4. Create a branch for local development::
 
@@ -76,13 +82,11 @@ Ready to contribute? Here's how to set up `mzx` for local development.
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox::
+5. Before opening a PR, run the checks the project uses::
 
-    $ flake8 mzx tests
-    $ python setup.py test or py.test
-    $ tox
-
-   To get flake8 and tox, just pip install them into your virtualenv.
+    $ make lint
+    $ make mypy
+    $ make test
 
 6. Commit your changes and push your branch to GitHub::
 
@@ -92,20 +96,22 @@ Ready to contribute? Here's how to set up `mzx` for local development.
 
 7. Submit a pull request through the GitHub website.
 
+.. _mzx: https://github.com/mass-matrix/mzx
+.. _uv: https://docs.astral.sh/uv/
+
 Pull Request Guidelines
 -----------------------
 
 Before you submit a pull request, check that it meets these guidelines:
 
-1. The pull request should include tests.
+1. The pull request should include tests when practical.
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
-   feature to the list in README.rst.
+   feature to the list in ``README.rst`` if it is user-facing.
 
 Tips
 ----
 
 To run a subset of tests::
 
-$ py.test tests.test_mzx
-
+    $ python -m pytest tests/test_vendor.py -v

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,17 @@
 History
 =======
 
+0.3.2 (2026-03-25)
+------------------
+* Documentation: README and Sphinx docs updated for clearer setup, prerequisites (Docker, Python 3.10+), installation from source, and usage; fixed incorrect license line in usage docs (GPLv3); corrected CONTRIBUTING workflow (ruff, pytest, ``make`` targets) and removed stale template text.
+* Packaging: add ``python -m mzx`` as the CLI entry (``__main__.py``); register ``mzx-gui`` under ``gui_scripts`` so Windows installs a GUI launcher via ``pythonw`` (no extra console window); document ``python -m mzx.gui`` when debugging or when scripts are not on ``PATH``.
+* Project metadata: PyPI “Documentation” URL now points to https://mzx.readthedocs.io/en/latest/ .
+* CI: install the package in editable mode before running tests so ``import mzx`` works; remove obsolete ``requirements.txt`` ``sed`` workaround from the workflow.
+* Makefile: ``help`` text for common targets (``install``, ``setup``, ``test``, etc.).
+* Tests: expanded coverage for ``msconvert``, ``convert_raw_file``, ``waters_convert``, CLI, ``run_cmd``, ``exclusion_string`` / Waters helpers, and ``python -m mzx``; tests import the ``mzx`` package instead of ``src.mzx``.
+
+**Full Changelog**: https://github.com/mass-matrix/mzx/compare/0.3.1...0.3.2
+
 0.3.1 (2025-06-26)
 ------------------
 * Bump setuptools from 75.1.0 to 78.1.1 in the pip group across 1 directory by @dependabot in https://github.com/mass-matrix/mzx/pull/27

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean clean-build clean-pyc clean-test dist docs help install lint mypy release servedocs setup test uninstall
+.PHONY: clean clean-build clean-pyc clean-test dist docs format help install lint lint-fix mypy release release-test servedocs setup test uninstall
 .DEFAULT_GOAL := help
 
 define BROWSER_PYSCRIPT
@@ -58,22 +58,22 @@ docs: ## generate Sphinx HTML documentation, including API docs
 	$(MAKE) -C docs html
 	$(BROWSER) docs/_build/html/index.html
 
-format:
+format: ## format source with ruff
 	ruff format .
 
-help:
+help: ## show this help
 	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
 
-install:
+install: ## editable install of mzx (use after `make setup` or with uv/pip in your env)
 	uv pip install -e .
 
-lint:
+lint: ## run ruff linter
 	ruff check .
 
-lint-fix:
+lint-fix: ## auto-fix ruff issues where possible
 	ruff check --fix .
 
-mypy:
+mypy: ## typecheck src/
 	mypy --strict-optional --check-untyped-defs --disallow-incomplete-defs --warn-unused-configs --follow-imports=normal src/
 
 release: dist ## package and upload a release
@@ -85,12 +85,12 @@ release-test: dist ## package and upload a release
 servedocs: docs ## compile the docs watching for changes
 	watchmedo shell-command -p '*.rst' -c '$(MAKE) -C docs html' -R -D .
 
-setup:
+setup: ## create .venv and install dev dependencies from requirements.txt
 	uv venv
 	uv pip install -r requirements.txt
 
-test:
+test: ## run tests with coverage
 	python -m pytest --capture=sys --capture=fd --cov=src/ -vv tests/
 
-uninstall:
+uninstall: ## remove mzx from the active environment
 	uv pip uninstall mzx

--- a/README.rst
+++ b/README.rst
@@ -23,96 +23,124 @@ mzx
         :alt: PyPI - Downloads
 
 
-Installing
-----------
+What it does
+------------
 
-System Requirements:
+**mzx** wraps `msconvert` from `ProteoWizard <https://proteowizard.sourceforge.io/>`_ inside Docker so you can convert vendor raw formats to open formats (mzML, MGF, mzXML, …) from the command line or an optional GUI.
 
-* Docker
-* Python3.10+ (Contains `PEP 636 <https://peps.python.org/pep-0636/>`_ )
-* Your favorite Python package manager (uv, pip, poetry, ...)
+Prerequisites
+-------------
 
-Install and update using `pip`\:
+* **Docker** — installed *and running* (the CLI calls ``docker run`` to execute msconvert).
+* **Python 3.10+**
+* **pip**, **uv**, or another PEP 517–compatible installer
+
+Install
+-------
 
 .. code-block:: console
 
         pip install -U mzx
 
-Usage
------
+Quick start
+-----------
 
-To run the cli command:
+#. Ensure Docker is running (``docker info`` should succeed).
+#. Convert a Thermo ``.raw`` file to mzML (default output format):
 
-.. code-block:: console
+   .. code-block:: console
 
-        mzx --type mgf /path/to/data.mgf
+        mzx /path/to/data.raw
 
-This will convert the `mgf` data to `mzml` by default.
+   The mzML is written next to the input file (same directory, ``.mzML`` extension).
 
-To run the gui:
+#. To choose another output format, set ``--type`` to ``mzml``, ``mgf``, or ``mzxml``:
+
+   .. code-block:: console
+
+        mzx --type mgf /path/to/data.raw
+
+See ``mzx --help`` for peak picking, indexing, Waters lockmass options, and more.
+
+GUI (experimental)
+------------------
+
+After install, start the GUI:
 
 .. code-block:: console
 
         mzx-gui
 
-Note: The gui is experimental
-
-You can also call the command from the module itself:
-
-.. code-block:: console
-
-        python -m mzx.cli /path/to/data.raw
+If the ``mzx-gui`` command is not on your ``PATH`` (common on Windows), use either:
 
 .. code-block:: console
 
         python -m mzx.gui
 
-Vendor Support
+or the Python Launcher for Windows:
+
+.. code-block:: doscon
+
+        py -m mzx.gui
+
+The CLI can always be run as ``python -m mzx`` (same as the ``mzx`` command).
+
+Vendor support
 --------------
 
-mzx utilizes proteowizard, and supports the following vendors: Agilent, Bruker, Sciex, Shimadzu, Thermo, and UIMF.
+Conversion uses ProteoWizard; supported vendors include Agilent, Bruker, Sciex, Shimadzu, Thermo, Waters, and UIMF. See the `ProteoWizard FAQ <https://proteowizard.sourceforge.io/faq.html>`_ for vendor-specific notes.
 
-For more information, please see the `proteowizard FAQ <https://proteowizard.sourceforge.io/faq.html>`
+Supported file formats (examples)
+---------------------------------
 
-Supported File Formats
-----------------------
-* .mgf
-* .mzML
-* .raw (Thermo)
-* .wiff (Sciex)
+* ``.mgf``
+* ``.mzML``
+* ``.raw`` (Thermo)
+* ``.wiff`` (Sciex)
 
 Features
 --------
-* Convert between various mass spectrometry file formats
-* Supports vendor formats: Agilent, Bruker, Sciex, etc.
-* CLI and experimental GUI for ease of use
+
+* Convert between common mass spectrometry interchange formats via msconvert
+* Vendor formats: Agilent, Bruker, Sciex, Thermo, Waters, and others supported by ProteoWizard
+* CLI and experimental GUI
 
 Documentation
 -------------
-Full documentation is available at `mzx.readthedocs.io <https://mzx.readthedocs.io/en/latest>`_
 
-Developer setup
----------------
+Full documentation: `mzx.readthedocs.io <https://mzx.readthedocs.io/en/latest>`_
 
-If you have uv installed, then you can a venv setup by running\:
+Development
+-----------
+
+From a clone of the repo, using `uv <https://docs.astral.sh/uv/>`_ (recommended):
 
 .. code-block:: console
 
         make setup
-
-While making changes to mzx, you can install/uninstall it from your local
-
-.. code-block:: console
-
+        source .venv/bin/activate   # Windows: .venv\Scripts\activate
         make install
 
+``make setup`` creates ``.venv`` and installs development dependencies from ``requirements.txt``. ``make install`` installs **mzx** in editable mode.
+
+Without ``make``, the same steps are:
+
 .. code-block:: console
 
-        make uninstall
+        uv venv
+        source .venv/bin/activate
+        uv pip install -r requirements.txt
+        uv pip install -e .
 
-Tests
------
+Run tests:
 
 .. code-block:: console
 
         make test
+
+Other useful targets: ``make lint``, ``make help``.
+
+License
+-------
+
+GNU General Public License v3 — see ``LICENSE``.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,38 +8,39 @@ Installation
 Stable release
 --------------
 
-To install mzx, run this command in your terminal:
+To install the latest release:
 
 .. code-block:: console
 
     $ pip install mzx
 
-This is the preferred method to install mzx, as it will always install the most recent stable release.
-
-If you don't have `pip`_ installed, this `Python installation guide`_ can guide
-you through the process.
-
-.. _pip: https://pip.pypa.io
-.. _Python installation guide: http://docs.python-guide.org/en/latest/starting/installation/
+Use a virtual environment if you do not want packages installed into your system Python. If you need help installing Python or ``pip``, see the `Python packaging user guide <https://packaging.python.org/en/latest/tutorials/installing-packages/>`_.
 
 
-From sources
-------------
+Prerequisites
+-------------
 
-The sources for mzx can be downloaded from the `Github repo`_.
-
-You can either clone the public repository:
-
-.. code-block:: console
-
-    $ git clone git@github.com:mass-matrix/mzx.git
+* **Python 3.10 or newer**
+* **Docker** — must be installed and the daemon running. mzx runs ProteoWizard's ``msconvert`` inside a container (see the main README for the image name).
 
 
-Once you have a copy of the source, you can install it with:
+From source (contributors)
+--------------------------
+
+Clone the repository (HTTPS works without SSH keys):
 
 .. code-block:: console
 
-    $ python setup.py install
+    $ git clone https://github.com/mass-matrix/mzx.git
+    $ cd mzx
 
+Create a virtual environment and install dependencies, then install mzx in editable mode:
 
-.. _Github repo: https://github.com/mass-matrix/mzx
+.. code-block:: console
+
+    $ python -m venv .venv
+    $ source .venv/bin/activate
+    $ pip install -r requirements.txt
+    $ pip install -e .
+
+If you use `uv <https://docs.astral.sh/uv/>`_, you can run ``make setup`` and ``make install`` from the project root instead (see ``README.rst``).

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -2,13 +2,52 @@
 Usage
 =====
 
-mzx Usage
----------------------
+Command line
+------------
+
+Default: convert a raw file to mzML in the same directory as the input:
 
 .. code-block:: console
 
-  mzx --type mgf /path/to/data.mgf
+  mzx /path/to/data.raw
 
+Other output formats:
 
-* Free software: MIT license
-* Documentation: https://mzx.readthedocs.io.
+.. code-block:: console
+
+  mzx --type mgf /path/to/data.raw
+  mzx --type mzxml /path/to/data.raw
+
+Full options:
+
+.. code-block:: console
+
+  mzx --help
+
+The same CLI is available as:
+
+.. code-block:: console
+
+  python -m mzx
+
+GUI
+---
+
+.. code-block:: console
+
+  mzx-gui
+
+If ``mzx-gui`` is not on your ``PATH`` (e.g. some Windows setups), use:
+
+.. code-block:: console
+
+  python -m mzx.gui
+
+The GUI is experimental; the CLI is recommended for scripting and automation.
+
+License
+-------
+
+mzx is licensed under the GNU General Public License v3.0. See the ``LICENSE`` file in the repository.
+
+* Documentation: https://mzx.readthedocs.io

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,10 +32,13 @@ dynamic = ["version"]
 
 [project.scripts]
 mzx = "mzx.cli:main"
+
+# gui_scripts: GUI launcher uses pythonw on Windows (no extra console window).
+[project.entry-points.gui_scripts]
 mzx-gui = "mzx.gui:main"
 
 [project.urls]
-Documentation = "https://readthedocs.org/projects/mzx"
+Documentation = "https://mzx.readthedocs.io/en/latest/"
 "Source Code" = "https://github.com/mass-matrix/mzx"
 "Issue Tracker" = "https://github.com/mass-matrix/mzx/issues"
 

--- a/src/mzx/__init__.py
+++ b/src/mzx/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 import os
 import re

--- a/src/mzx/__main__.py
+++ b/src/mzx/__main__.py
@@ -1,0 +1,6 @@
+"""Run the CLI entry point via ``python -m mzx`` (same as the ``mzx`` console script)."""
+
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,48 @@
+"""Tests for mzx.cli main()."""
+
+import sys
+from unittest import mock
+
+from mzx.cli import main
+
+
+def test_cli_calls_convert_raw_file_with_parsed_args(monkeypatch) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "mzx",
+            "/data/file.raw",
+            "--type",
+            "mgf",
+            "--index",
+            "--peak_picking",
+            "all",
+        ],
+    )
+    with mock.patch("mzx.cli.convert_raw_file") as mock_conv:
+        main()
+    mock_conv.assert_called_once()
+    params = mock_conv.call_args[0][0]
+    assert params["infile"] == "/data/file.raw"
+    assert params["type"] == "mgf"
+    assert params["index"] is True
+    assert params["peak_picking"] == "all"
+
+
+def test_cli_logs_exception_on_conversion_failure(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["mzx", "/nope.raw"])
+    with mock.patch("mzx.cli.convert_raw_file", side_effect=RuntimeError("boom")):
+        with mock.patch("mzx.cli.logger") as log:
+            main()
+    log.error.assert_called()
+
+
+def test_cli_passes_vendor_from_vendor_name_from_file(monkeypatch) -> None:
+    """CLI does not use --vendor today; vendor is inferred from the path."""
+    monkeypatch.setattr(sys, "argv", ["mzx", "/x.raw"])
+    with mock.patch("mzx.cli.convert_raw_file") as mock_conv:
+        with mock.patch("mzx.cli.vendor.vendor_name_from_file", return_value="Thermo"):
+            main()
+    params = mock_conv.call_args[0][0]
+    assert params["vendor"] == "Thermo"

--- a/tests/test_convert_raw_file.py
+++ b/tests/test_convert_raw_file.py
@@ -1,0 +1,72 @@
+"""Tests for convert_raw_file vendor routing."""
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from mzx import RawFileConversionError, convert_raw_file
+
+
+def _minimal_params(infile: str, vendor: str):
+    return {
+        "infile": infile,
+        "index": True,
+        "sortbyscan": False,
+        "peak_picking": "msms",
+        "remove_zeros": True,
+        "vendor": vendor,
+        "outfile": None,
+        "type": "mzml",
+        "overwrite": False,
+        "debug": False,
+        "verbose": False,
+        "lockmass_disabled": False,
+        "lockmass": False,
+        "neg_lockmass": None,
+        "pos_lockmass": None,
+        "lockmass_tolerance": None,
+        "lockmass_function_exclude": None,
+    }
+
+
+@pytest.mark.parametrize(
+    "vendor",
+    ["Thermo", "thermo", "Agilent", "bruker", "Bruker"],
+)
+@mock.patch("mzx.msconvert", return_value="/out/file.mzML")
+def test_convert_raw_file_delegates_to_msconvert(
+    mock_ms, tmp_path: Path, vendor: str
+) -> None:
+    f = tmp_path / "s.raw"
+    f.write_text("x")
+    out = convert_raw_file(_minimal_params(str(f), vendor))
+    assert out == "/out/file.mzML"
+    mock_ms.assert_called_once()
+
+
+@mock.patch("mzx.msconvert", return_value="/out/u.mzML")
+def test_convert_raw_file_unspecified_uses_msconvert(mock_ms, tmp_path: Path) -> None:
+    f = tmp_path / "s.txt"
+    f.write_text("x")
+    convert_raw_file(_minimal_params(str(f), "unspecified"))
+    mock_ms.assert_called_once()
+
+
+@mock.patch("mzx.waters_convert", return_value="/out/w.mzML")
+def test_convert_raw_file_waters(mock_wc, tmp_path: Path) -> None:
+    f = tmp_path / "w.raw"
+    f.write_text("x")
+    out = convert_raw_file(_minimal_params(str(f), "waters"))
+    assert out == "/out/w.mzML"
+    mock_wc.assert_called_once()
+
+
+def test_convert_raw_file_waters_propagates_as_raw_file_error(tmp_path: Path) -> None:
+    with pytest.raises(RawFileConversionError, match="_extern.inf"):
+        convert_raw_file(_minimal_params(str(tmp_path), "waters"))
+
+
+def test_convert_raw_file_unsupported_vendor() -> None:
+    with pytest.raises(RawFileConversionError, match="Unsupported vendor"):
+        convert_raw_file(_minimal_params("/tmp/fake.raw", "unknown_vendor"))

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1,9 +1,9 @@
 import mock
 import subprocess
-from src.mzx import docker  # Adjust to your module's path
+from mzx import docker
 
 
-@mock.patch("src.mzx.docker.subprocess.run", return_value=None)
+@mock.patch("mzx.docker.subprocess.run", return_value=None)
 def test_docker_running(mock_run):
     """Test the case where Docker is running successfully."""
     result = docker.check_running()
@@ -14,7 +14,7 @@ def test_docker_running(mock_run):
     assert result is True
 
 
-@mock.patch("src.mzx.docker.subprocess.run")
+@mock.patch("mzx.docker.subprocess.run")
 def test_docker_not_running(mock_run):
     """Test the case where Docker is not running and command fails."""
     # Mock subprocess.run to raise CalledProcessError to simulate failure

--- a/tests/test_exclusion_and_format.py
+++ b/tests/test_exclusion_and_format.py
@@ -1,0 +1,45 @@
+"""Tests for pure helpers in mzx.__init__."""
+
+import pytest
+
+from mzx import exclusion_string, format_function_number, modify_waters_scan_header
+
+
+@pytest.mark.parametrize(
+    "x, expected",
+    [
+        (1, "2-"),
+        (2, "1 3-"),
+        (3, "1-2 4-"),
+        (5, "1-4 6-"),
+        (10, "1-9 11-"),
+    ],
+)
+def test_exclusion_string_examples(x: int, expected: str) -> None:
+    assert exclusion_string(x) == expected
+
+
+@pytest.mark.parametrize("bad", [0, -1, -100])
+def test_exclusion_string_rejects_non_positive(bad: int) -> None:
+    with pytest.raises(ValueError, match="positive integer"):
+        exclusion_string(bad)
+
+
+def test_format_function_number_match() -> None:
+    s, n = format_function_number("foo REFERENCE Function 7 bar")
+    assert s == "_FUNC007"
+    assert n == 7
+
+
+def test_format_function_number_no_match() -> None:
+    assert format_function_number("no function here") is None
+
+
+def test_modify_waters_scan_header_no_match_returns_line() -> None:
+    line = "<spectrum index='0'/>"
+    assert modify_waters_scan_header(line) is line
+
+
+def test_modify_waters_scan_header_preserves_unmatched_spectrum_line() -> None:
+    line = '  <spectrum index="99" id="other">'
+    assert modify_waters_scan_header(line) == line

--- a/tests/test_main_module.py
+++ b/tests/test_main_module.py
@@ -1,0 +1,16 @@
+"""Smoke test for python -m mzx."""
+
+import subprocess
+import sys
+
+
+def test_mzx_module_help_exits_zero() -> None:
+    r = subprocess.run(
+        [sys.executable, "-m", "mzx", "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert r.returncode == 0
+    assert "usage:" in r.stdout.lower()
+    assert "file" in r.stdout.lower()

--- a/tests/test_msconvert.py
+++ b/tests/test_msconvert.py
@@ -1,0 +1,165 @@
+"""Tests for msconvert() Docker command construction (Docker not run)."""
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from mzx import docker_image, msconvert
+
+
+def _base_params(infile: str, **overrides):
+    p = {
+        "infile": infile,
+        "index": True,
+        "sortbyscan": False,
+        "peak_picking": "msms",
+        "remove_zeros": True,
+        "vendor": "thermo",
+        "outfile": None,
+        "type": "mzml",
+        "overwrite": False,
+        "debug": False,
+        "verbose": False,
+        "lockmass_disabled": False,
+        "lockmass": False,
+        "neg_lockmass": None,
+        "pos_lockmass": None,
+        "lockmass_tolerance": None,
+        "lockmass_function_exclude": None,
+    }
+    p.update(overrides)
+    return p
+
+
+@mock.patch("mzx.run_cmd", return_value="")
+def test_msconvert_builds_docker_command_and_returns_output_path(
+    mock_run, tmp_path: Path
+) -> None:
+    f = tmp_path / "run.raw"
+    f.write_text("x")
+    params = _base_params(str(f))
+    out = msconvert(params)
+    assert out.endswith("run.mzML")
+    mock_run.assert_called_once()
+    cmd = mock_run.call_args[0][0]
+    assert "docker run --rm" in cmd
+    assert docker_image in cmd
+    assert "wine msconvert" in cmd
+    assert "run.raw" in cmd
+    assert "--mzML" in cmd
+
+
+@mock.patch("mzx.run_cmd", return_value="")
+def test_msconvert_output_format_mgf(mock_run, tmp_path: Path) -> None:
+    f = tmp_path / "a.raw"
+    f.write_text("x")
+    out = msconvert(_base_params(str(f), type="mgf"))
+    assert out.endswith("a.mgf")
+    assert "--mgf" in mock_run.call_args[0][0]
+
+
+@mock.patch("mzx.run_cmd", return_value="")
+def test_msconvert_output_format_mzxml(mock_run, tmp_path: Path) -> None:
+    f = tmp_path / "a.raw"
+    f.write_text("x")
+    out = msconvert(_base_params(str(f), type="mzxml"))
+    assert out.endswith("a.mzXML")
+    assert "--mzXML" in mock_run.call_args[0][0]
+
+
+@mock.patch("mzx.run_cmd", return_value="")
+def test_msconvert_custom_outfile_basename(mock_run, tmp_path: Path) -> None:
+    f = tmp_path / "in.raw"
+    f.write_text("x")
+    out = msconvert(_base_params(str(f), outfile=str(tmp_path / "custom.mzML")))
+    assert out.endswith("custom.mzML")
+    mock_run.assert_called_once()
+
+
+@mock.patch("mzx.run_cmd", return_value="")
+@pytest.mark.parametrize(
+    "peak_picking, needle",
+    [
+        ("all", "peakPicking true 1-"),
+        ("ms1", "peakPicking true 1"),
+        ("msms", "peakPicking true 2-"),
+    ],
+)
+def test_msconvert_peak_picking_filters(
+    mock_run, tmp_path: Path, peak_picking: str, needle: str
+) -> None:
+    f = tmp_path / "x.raw"
+    f.write_text("x")
+    msconvert(_base_params(str(f), peak_picking=peak_picking))
+    assert needle in mock_run.call_args[0][0]
+
+
+@mock.patch("mzx.run_cmd", return_value="")
+def test_msconvert_peak_picking_off_adds_no_peak_filter(
+    mock_run, tmp_path: Path
+) -> None:
+    f = tmp_path / "x.raw"
+    f.write_text("x")
+    msconvert(_base_params(str(f), peak_picking="off"))
+    cmd = mock_run.call_args[0][0]
+    assert "peakPicking" not in cmd
+
+
+@mock.patch("mzx.run_cmd", return_value="")
+def test_msconvert_noindex_and_sort(mock_run, tmp_path: Path) -> None:
+    f = tmp_path / "x.raw"
+    f.write_text("x")
+    msconvert(_base_params(str(f), index=False, sortbyscan=True))
+    cmd = mock_run.call_args[0][0]
+    assert "--noindex" in cmd
+    assert "sortByScanTime" in cmd
+
+
+@mock.patch("mzx.run_cmd", return_value="")
+def test_msconvert_remove_zeros_false_skips_filter(mock_run, tmp_path: Path) -> None:
+    f = tmp_path / "x.raw"
+    f.write_text("x")
+    msconvert(_base_params(str(f), remove_zeros=False))
+    cmd = mock_run.call_args[0][0]
+    assert "zeroSamples" not in cmd
+
+
+@mock.patch("mzx.run_cmd", return_value="")
+def test_msconvert_lockmass_defaults_when_values_none(mock_run, tmp_path: Path) -> None:
+    f = tmp_path / "x.raw"
+    f.write_text("x")
+    msconvert(
+        _base_params(
+            str(f),
+            lockmass=True,
+            neg_lockmass=None,
+            pos_lockmass=None,
+            lockmass_tolerance=None,
+        )
+    )
+    cmd = mock_run.call_args[0][0]
+    assert "556.2771" in cmd
+    assert "554.2615" in cmd
+    assert "0.1" in cmd
+
+
+@mock.patch("mzx.run_cmd", return_value="")
+def test_msconvert_lockmass_and_scan_event_exclude(mock_run, tmp_path: Path) -> None:
+    f = tmp_path / "x.raw"
+    f.write_text("x")
+    msconvert(
+        _base_params(
+            str(f),
+            lockmass=True,
+            pos_lockmass=500.0,
+            neg_lockmass=500.5,
+            lockmass_tolerance=0.2,
+            lockmass_function_exclude=3,
+        )
+    )
+    cmd = mock_run.call_args[0][0]
+    assert "lockmassRefiner" in cmd
+    assert "mz=500.0" in cmd
+    assert "scanEvent" in cmd
+    assert "1-2 4-" in cmd  # exclusion_string(3)

--- a/tests/test_process_waters_file.py
+++ b/tests/test_process_waters_file.py
@@ -1,0 +1,18 @@
+"""Tests for in-place Waters mzML scan header rewriting."""
+
+from pathlib import Path
+
+from mzx import process_waters_scan_headers
+
+
+def test_process_waters_scan_headers_rewrites_file(tmp_path: Path) -> None:
+    p = tmp_path / "small.mzML"
+    lines = [
+        '        <spectrum index="0" id="function=1 process=0 scan=1" />\n',
+        "        <other />\n",
+    ]
+    p.write_text("".join(lines), encoding="utf8")
+    process_waters_scan_headers(str(p))
+    out = p.read_text(encoding="utf8")
+    assert "fscan=1" in out
+    assert "scan=1 fscan=1" in out

--- a/tests/test_run_cmd.py
+++ b/tests/test_run_cmd.py
@@ -1,0 +1,36 @@
+"""Tests for subprocess wrapper run_cmd."""
+
+from unittest import mock
+
+from mzx import run_cmd
+
+
+def test_run_cmd_collects_stdout() -> None:
+    class FakeStdout:
+        def readline(self):
+            return ""
+
+    class FakeProc:
+        stdout = FakeStdout()
+
+    with mock.patch("mzx.subprocess.Popen", return_value=FakeProc()) as popen:
+        out = run_cmd("echo hello")
+
+    popen.assert_called_once()
+    assert out == ""
+
+
+def test_run_cmd_accumulates_multiple_lines() -> None:
+    remaining = ["first\n", "second\n", ""]
+
+    class FakeStdout:
+        def readline(self):
+            return remaining.pop(0)
+
+    class FakeProc:
+        stdout = FakeStdout()
+
+    with mock.patch("mzx.subprocess.Popen", return_value=FakeProc()):
+        out = run_cmd("dummy")
+
+    assert out == "first\nsecond\n"

--- a/tests/test_vendor.py
+++ b/tests/test_vendor.py
@@ -1,8 +1,7 @@
 import pytest
 from unittest import mock
 
-# Assuming your function is in a module named `vendor_utils.py`
-from src.mzx import WatersConvertException, vendor, waters_convert
+from mzx import WatersConvertException, vendor, waters_convert
 
 
 @pytest.mark.parametrize(

--- a/tests/test_waters_convert.py
+++ b/tests/test_waters_convert.py
@@ -1,0 +1,61 @@
+"""Tests for waters_convert() happy path (msconvert mocked)."""
+
+from pathlib import Path
+from unittest import mock
+
+from mzx import waters_convert
+
+
+def _waters_params(infile: str):
+    return {
+        "infile": infile,
+        "index": False,
+        "sortbyscan": False,
+        "peak_picking": "msms",
+        "remove_zeros": True,
+        "vendor": "waters",
+        "outfile": None,
+        "type": "mzml",
+        "overwrite": False,
+        "debug": False,
+        "verbose": False,
+        "lockmass": None,
+        "lockmass_disabled": True,
+        "lockmass_function_exclude": None,
+        "lockmass_tolerance": None,
+        "neg_lockmass": None,
+        "pos_lockmass": None,
+    }
+
+
+@mock.patch("mzx.msconvert", return_value="/tmp/out/dir/file.mzML")
+def test_waters_convert_with_extern_inf_calls_msconvert(
+    mock_ms, tmp_path: Path
+) -> None:
+    d = tmp_path / "waters_dir"
+    d.mkdir()
+    (d / "foo_extern.inf").write_text("no reference line\n", encoding="latin-1")
+    out = waters_convert(_waters_params(str(d)))
+    assert out == "/tmp/out/dir/file.mzML"
+    mock_ms.assert_called_once()
+    passed = mock_ms.call_args[0][0]
+    assert passed["vendor"] == "waters"
+    assert passed["type"] == "mzml"
+    assert passed["index"] is True
+
+
+@mock.patch("mzx.msconvert", return_value="/out.mzML")
+def test_waters_convert_lockmass_reference_line_sets_exclude(
+    mock_ms, tmp_path: Path
+) -> None:
+    d = tmp_path / "w"
+    d.mkdir()
+    (d / "x_extern.inf").write_text(
+        "REFERENCE Function 2 something\n", encoding="latin-1"
+    )
+    p = _waters_params(str(d))
+    p["lockmass_disabled"] = False
+    waters_convert(p)
+    passed = mock_ms.call_args[0][0]
+    assert passed["lockmass"] is True
+    assert passed["lockmass_function_exclude"] == 2

--- a/tests/test_waters_format_scan_headers.py
+++ b/tests/test_waters_format_scan_headers.py
@@ -1,4 +1,4 @@
-from src import mzx
+import mzx
 
 
 def test_modify_waters_scan_header():


### PR DESCRIPTION
- Updates documentation around installation/usage
- Adjusts script command to `mzx.gui` rather than `mzx-gui` since that doesn't work on Windows
